### PR TITLE
Update README to show findings with PNIDGrab working on Arch

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,9 +11,14 @@ Because PNIDGrab goes in Cemu's memory and reads from it, anti virus software ma
 The binary is not signed by Apple, because I don't pay Apple $99 per year for a paid developer account. You will get an error saying that Apple can't verify that this application is free from malware. The easiest solution to that issue is opening a Terminal and running `sudo xattr -cr /Applications/PNIDGrab.app/`. After that, you can run the application as usual and won't have to redo this step again until you update the application.
 
 ### Linux
-Arch Linux has a weird issue with their permission system if you run a Wayland session. Even though you get Polkit to ask for your password, the application will likely not run. This is also not specific to PNIDGrab. I've seen the exact same issue with GParted on my CachyOS installation. Other distros don't seem to be affected.
+With certain Linux Distros, you may encounter a weird issue with their permission system if you run a Wayland session. Even though you get Polkit to ask for your password, the application will likely not run. [This is because by default ptrace protection is enabled.](https://wiki.ubuntu.com/SecurityTeam/Roadmap/KernelHardening#ptrace_Protection)
+>This behavior is controlled via the /proc/sys/kernel/yama/ptrace_scope sysctl value. The default is "1" to block non-child ptrace.
 
-If you're affected by this issue, I'd recommend to try and run it on a different distro inside a Distrobox. If you don't wish to use a Distrobox or that fails too, grab the last CLI-only release (2.x). 
+**Extremely dangerous workaround** as of right now to achieve the use of PNIDGrab is to go in `/etc/sysctl.d/`, make a file called `10-ptrace.conf` and put `kernel.yama.ptrace_scope = 0` in there.
+
+Alternatively: you can do `su root` and run the AppImage that way.
+
+**If you wish to not subject yourself to this!!** I'd recommend to try and run it on a different distro inside a Distrobox. If you don't wish to use a Distrobox or that fails too, grab the last CLI-only release (2.x).
 
 ## Credits
 * [c8ff](https://github.com/c8ff) for finding a method to get Cemu's base address without reading the log file


### PR DESCRIPTION
As found by Jerry & (accidentally a long time ago and forgot to mention it might being a factor) by me, certain distros disallow of ptrace by default or have a workaround for it. updated the readme to reflect this finding.