### PR TITLE
ad-hoc sign with proper entitlements

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -49,6 +49,7 @@ jobs:
           </dict>
           </plist>
           PLIST
+          codesign --sign "-" --entitlements "${{github.workspace}}/app.entitlements.plist" --force --deep --preserve-metadata=entitlements,requirements,flags,runtime --timestamp $APP_ROOT
           DMG_DIR="dist/dmg"
           mkdir -p "$DMG_DIR"
           cp -R "$APP_ROOT" "$DMG_DIR/"

--- a/app.entitlements.plist
+++ b/app.entitlements.plist
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
+    <true/>
+    <key>com.apple.security.automation.apple-events</key>
+    <true/>
+    <key>com.apple.security.cs.disable-library-validation</key>
+    <true/>
+    <key>com.apple.security.cs.debugger</key>
+    <true/>
+    <key>com.apple.security.get-task-allow</key>
+    <true/>
+    <key>com.apple.security.cs.allow-jit</key>
+    <true/>
+</dict>
+</plist>

--- a/app.entitlements.plist
+++ b/app.entitlements.plist
@@ -2,17 +2,7 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-    <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
-    <true/>
-    <key>com.apple.security.automation.apple-events</key>
-    <true/>
-    <key>com.apple.security.cs.disable-library-validation</key>
-    <true/>
     <key>com.apple.security.cs.debugger</key>
-    <true/>
-    <key>com.apple.security.get-task-allow</key>
-    <true/>
-    <key>com.apple.security.cs.allow-jit</key>
     <true/>
 </dict>
 </plist>


### PR DESCRIPTION
Our favorite Fruit company now forces entitlements in macOS 26.4 for task_for_pid() it seems.

Tested on a MacBook Neo with A18 Pro and 8GB RAM